### PR TITLE
業界特化カタログを業界特化サービスカタログに変更

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -27,7 +27,7 @@ export function Header() {
       <div className="container flex h-16 items-center justify-between">
         <div className="flex items-center gap-2">
           <Link href="/" className="font-bold text-xl">
-            業界特化<span className="text-green-600">カタログ</span>
+            業界特化<span className="text-green-600">サービスカタログ</span>
           </Link>
         </div>
         <nav className="hidden md:flex items-center gap-6">


### PR DESCRIPTION
ヘッダーコンポーネントでアプリケーションのタイトル表示を「業界特化カタログ」から「業界特化サービスカタログ」に更新しました。

Closes #issue-13

Generated with [Claude Code](https://claude.ai/code)